### PR TITLE
Implement separate long build queues

### DIFF
--- a/src/job.rb
+++ b/src/job.rb
@@ -7,9 +7,9 @@ require_relative "queue_types"
 # Information representing a CI job.
 class Job
   NAME_REGEX =
-    /\A(?<runner>\d+(?:\.\d+)?(?:-arm64)?(?:-cross)?)-(?<run_id>\d+)(?:-(?<run_attempt>\d+))?(?:-(?<tag>[a-z]+))?\z/
+    /\A(?<runner>\d+(?:\.\d+)?(?:-arm64)?(?:-cross)?)-(?<run_id>\d+)(?:-(?<run_attempt>\d+))?(?:-(?<tags>[-a-z]+))?\z/
 
-  attr_reader :runner_name, :repository, :github_id, :secret
+  attr_reader :runner_name, :repository, :github_id, :secret, :group
   attr_writer :orka_setup_timeout
   attr_accessor :github_state, :orka_vm_id, :orka_setup_time, :orka_start_attempts, :runner_completion_time
 
@@ -26,6 +26,7 @@ class Job
     @orka_start_attempts = 0
     @secret = secret || SecureRandom.hex(32)
     @runner_completion_time = nil
+    @group = long_build? ? :long : :default
   end
 
   def os
@@ -44,8 +45,12 @@ class Job
     @runner_name[NAME_REGEX, :run_attempt]
   end
 
-  def tag
-    @runner_name[NAME_REGEX, :tag]
+  def tags
+    @runner_name[NAME_REGEX, :tags]&.split("-").to_a
+  end
+
+  def long_build?
+    tags.include?("long")
   end
 
   def runner_labels

--- a/src/job_queue.rb
+++ b/src/job_queue.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative "shared_state"
+
+# A variation of `Thread::Queue` that allows us to prioritise certain types of jobs.
+class JobQueue
+  def initialize(queue_type)
+    @mutex = Mutex.new
+    @queue = Hash.new { |h, k| h[k] = [] }
+    @queue_type = queue_type
+    @condvar = ConditionVariable.new
+  end
+
+  def <<(job)
+    @mutex.synchronize do
+      @queue[job.group] << job
+      @condvar.signal
+    end
+  end
+
+  def pop
+    @mutex.synchronize do
+      loop do
+        running_long_build_count = SharedState.instance.running_jobs(@queue_type).count(&:long_build?)
+
+        if running_long_build_count < 2 && !@queue[:long].empty?
+          break @queue[:long].shift
+        elsif !@queue[:default].empty?
+          break @queue[:default].shift
+        else
+          @condvar.wait(@mutex)
+        end
+      end
+    end
+  end
+end

--- a/src/orka_start_processor.rb
+++ b/src/orka_start_processor.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "thread_runner"
+require_relative "job_queue"
 
 require "timeout"
 
@@ -21,9 +22,9 @@ class OrkaStartProcessor < ThreadRunner
 
   attr_reader :queue
 
-  def initialize(name)
+  def initialize(queue_type, name)
     super("#{self.class.name} (#{name})")
-    @queue = Queue.new
+    @queue = JobQueue.new(queue_type)
   end
 
   def pausable?

--- a/src/shared_state.rb
+++ b/src/shared_state.rb
@@ -81,7 +81,7 @@ class SharedState
     @file_mutex = Mutex.new
 
     @orka_start_processors = QueueTypes.to_h do |type|
-      [type, OrkaStartProcessor.new(QueueTypes.name(type))]
+      [type, OrkaStartProcessor.new(type, QueueTypes.name(type))]
     end
     @orka_stop_processor = OrkaStopProcessor.new
     @orka_timeout_processor = OrkaTimeoutProcessor.new
@@ -213,6 +213,10 @@ class SharedState
   def free_slot?(waiting_job)
     max_slots = QueueTypes.slots(waiting_job.queue_type)
     @jobs.count { |job| job.queue_type == waiting_job.queue_type && !job.orka_vm_id.nil? } < max_slots
+  end
+
+  def running_jobs(queue_type)
+    jobs.select { |job| job.queue_type == queue_type && !job.orka_vm_id.nil? }
   end
 
   private


### PR DESCRIPTION
This implements a separate queue for long-running builds that are
identified by a suffix `-long` in the runner name.

The values for `slots` in `src/queue_types.rb` is probably wrong, and
will need adjusting.

This should achieve having an entirely separate queue for long build
jobs. What isn't clear to me is whether this leads to unused capacity
when there are no long build jobs to be done but there are queued short
build jobs waiting.
