### PR TITLE
job: support Intel runners with `-x86_64` in runner name

### DIFF
--- a/src/job.rb
+++ b/src/job.rb
@@ -6,11 +6,14 @@ require_relative "queue_types"
 
 # Information representing a CI job.
 class Job
-  # rubocop:disable Layout/LineLength
-  # Splitting the long line up is probably just going to make things worse.
-  NAME_REGEX =
-    /\A(?<runner>\d+(?:\.\d+)?(?:-(?:arm|x86_)64)?(?:-cross)?)-(?<run_id>\d+)(?:-(?<run_attempt>\d+))?(?:-(?<tags>[-a-z]+))?\z/
-  # rubocop:enable Layout/LineLength
+  NAME_REGEX = /
+    \A
+      (?<runner>\d+(?:\.\d+)?(?:-(?:arm|x86_)64)?(?:-cross)?)
+      -(?<run_id>\d+)
+      (?:-(?<run_attempt>\d+))?
+      (?:-(?<tags>[-a-z]+))?
+    \z
+  /x
 
   attr_reader :runner_name, :repository, :github_id, :secret, :group
   attr_writer :orka_setup_timeout

--- a/src/job.rb
+++ b/src/job.rb
@@ -6,8 +6,11 @@ require_relative "queue_types"
 
 # Information representing a CI job.
 class Job
+  # rubocop:disable Layout/LineLength
+  # Splitting the long line up is probably just going to make things worse.
   NAME_REGEX =
-    /\A(?<runner>\d+(?:\.\d+)?(?:-arm64)?(?:-cross)?)-(?<run_id>\d+)(?:-(?<run_attempt>\d+))?(?:-(?<tags>[-a-z]+))?\z/
+    /\A(?<runner>\d+(?:\.\d+)?(?:-(?:arm|x86_)64)?(?:-cross)?)-(?<run_id>\d+)(?:-(?<run_attempt>\d+))?(?:-(?<tags>[-a-z]+))?\z/
+  # rubocop:enable Layout/LineLength
 
   attr_reader :runner_name, :repository, :github_id, :secret, :group
   attr_writer :orka_setup_timeout


### PR DESCRIPTION
We currently download unneeded artifacts in CI runs because the glob
for, say, `bottles_14*` matches artifacts built on both Intel and M1
runners.

Adding the architecture to the runner name will allow us to use a more
specific glob which prevents needlessly downloading artifacts that we
won't use.
