### PR TITLE
index.erb: sort jobs by `run_id`

### DIFF
--- a/src/views/index.erb
+++ b/src/views/index.erb
@@ -72,7 +72,7 @@
                   </tr>
                 </thead>
                 <tbody>
-                  <% state.jobs.each do |job| %>
+                  <% state.jobs.sort_by(&:run_id).each do |job| %>
                   <tr>
                     <td class="d-none d-sm-table-cell">
                       <div class="position-relative">


### PR DESCRIPTION
This will make it easier to match runs in the orchestrator with PRs in
Homebrew/core, since it will list together VMs deployed for a specific
PR next to each other.
