### PR TITLE
dependabot.yml: remove time and timezones.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     directory: /
     schedule:
       interval: daily
-      time: "14:30"
-      timezone: Europe/London
     allow:
       - dependency-type: all
     # The actions in triage-issues.yml are updated in the Homebrew/.github repo
@@ -20,8 +18,6 @@ updates:
     directory: /
     schedule:
       interval: daily
-      time: "14:30"
-      timezone: Europe/London
     allow:
       - dependency-type: all
     commit-message:


### PR DESCRIPTION
Let's be consistent across the Homebrew organisation here.