### PR TITLE
Add localised queue signalling on free slots

### DIFF
--- a/src/orka_stop_processor.rb
+++ b/src/orka_stop_processor.rb
@@ -46,7 +46,7 @@ class OrkaStopProcessor < ThreadRunner
               log "VM for job #{job.runner_name} already deleted!"
             end
             job.orka_vm_id = nil
-            state.orka_free_condvar.broadcast
+            state.orka_start_processors[job.queue_type].signal_free(job.group)
             log "VM for job #{job.runner_name} deleted."
           end
         end

--- a/src/shared_state.rb
+++ b/src/shared_state.rb
@@ -62,7 +62,7 @@ class SharedState
 
   attr_reader :config,
               :orka_client,
-              :orka_mutex, :orka_free_condvar, :github_mutex, :github_metadata_condvar,
+              :orka_mutex, :github_mutex, :github_metadata_condvar,
               :orka_start_processors, :orka_stop_processor, :orka_timeout_processor, :github_watcher,
               :github_runner_metadata,
               :jobs, :expired_jobs
@@ -75,7 +75,6 @@ class SharedState
     @orka_client = OrkaAPI::Client.new(@config.orka_base_url, token: @config.orka_token)
 
     @orka_mutex = Mutex.new
-    @orka_free_condvar = ConditionVariable.new
     @github_mutex = Mutex.new
     @github_metadata_condvar = ConditionVariable.new
     @file_mutex = Mutex.new


### PR DESCRIPTION
Instead of a global free slot condition variable, be smarter and signal only the connected start processor of the free slot.

This on its own doesn't do very much and saves a very small number of CPU cycles, but it does enable the flexibility to pass on this signal to the internal job queue condition variable. This is useful as since we added queue categorisation, a waiting queue no longer means it is empty and it could just mean there were no free slots for that specific subqueue, so we should signal it when there's a potential change in job slot distribution.