### PR TITLE
queue_type: temporarily decrease arm64 queue size

### DIFF
--- a/src/queue_type.rb
+++ b/src/queue_type.rb
@@ -30,7 +30,7 @@ class QueueType < T::Enum
     when MacOS_x86_64
       12
     when MacOS_Arm64
-      10
+      8
     else
       T.absurd(self)
     end


### PR DESCRIPTION
Due to a failing node.