### PR TITLE
Dockerfile: move apk add/del into same layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 ARG RUBY_VERSION
 FROM ruby:$RUBY_VERSION-alpine
 
-RUN apk add --no-cache --virtual .build-deps build-base
-
 WORKDIR /app
-COPY .ruby-version Gemfile* /app
+COPY .ruby-version Gemfile* /app/
+
 ENV BUNDLE_DEPLOYMENT=1
-RUN bundle install && apk del --no-cache .build-deps
+
+RUN apk add --no-cache --virtual .build-deps build-base && \
+    bundle install && \
+    apk del --no-cache .build-deps
 
 COPY src /app
 COPY gen /gen


### PR DESCRIPTION
Reduced image size from ~337 MiB to ~105 MiB. Previously, due to `apk add` and `apk del` being in different `RUN` statements, the contents of `build-base` (and its deps) are still retained in the resulting image.