### PR TITLE
Gemfile: revert kube-dsl to 0.8.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,7 @@ updates:
       timezone: Europe/London
     allow:
       - dependency-type: all
+    versioning-strategy: lockfile-only
     commit-message:
       prefix: Gemfile.lock
     groups:
@@ -40,28 +41,7 @@ updates:
           - minor
           - patch
 
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: daily
-    allow:
-      - dependency-type: all
-
   - package-ecosystem: docker
-    directory: /
-    schedule:
-      interval: daily
-    allow:
-      - dependency-type: all
-
-  - package-ecosystem: devcontainers
-    directory: /
-    schedule:
-      interval: daily
-    allow:
-      - dependency-type: all
-
-  - package-ecosystem: pip
     directory: /
     schedule:
       interval: daily

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby file: ".ruby-version"
 
 gem "faraday-retry" # for octokit
 gem "jwt"
-gem "kube-dsl"
+gem "kube-dsl", "!= 0.8.2"
 gem "octokit"
 gem "puma"
 gem "rackup"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
     json (2.10.2)
     jwt (2.10.1)
       base64
-    kube-dsl (0.8.2)
+    kube-dsl (0.8.1)
       dry-inflector (~> 0.2)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
@@ -141,7 +141,7 @@ PLATFORMS
 DEPENDENCIES
   faraday-retry
   jwt
-  kube-dsl
+  kube-dsl (!= 0.8.2)
   octokit
   puma
   rackup


### PR DESCRIPTION
#472 broke the orchestrator.

I've submitted a fix for 0.8.3 so should be good again then.

This will cancel the currently running Rust dependents run - I'm sorry.